### PR TITLE
Updated mail config file to fix password reset emails

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'driver' => env('MAIL_DRIVER', 'smtp'),
+    'driver' => env('MAIL_DRIVER'),
 
     /*
     |--------------------------------------------------------------------------
@@ -28,7 +28,7 @@ return [
     |
     */
 
-    'host' => env('MAIL_HOST', 'smtp.gmail.com'),
+    'host' => env('MAIL_HOST'),
 
     /*
     |--------------------------------------------------------------------------
@@ -41,7 +41,7 @@ return [
     |
     */
 
-    'port' => env('MAIL_PORT', 587),
+    'port' => env('MAIL_PORT'),
 
     /*
     |--------------------------------------------------------------------------
@@ -54,7 +54,7 @@ return [
     |
     */
 
-    'from' => ['address' => 'mikhail.rudanov@gmail.com', 'name' => 'mephi22.ru'],
+    'from' => ['address' => env('MAIL_USERNAME'), 'name' => 'mephi22.ru'],
 
     /*
     |--------------------------------------------------------------------------
@@ -67,7 +67,7 @@ return [
     |
     */
 
-    'encryption' => env('MAIL_ENCRYPTION', 'tls'),
+    'encryption' => env('MAIL_ENCRYPTION'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Поправил конфиг для работы с почтой `mail.php` для того, чтобы восстановить отправку email-ов.
- Заиспользовал общую почту algorithms.theory@yandex.ru для smtp.
- В настройках аккаунта в Яндекс.Паспорте сгенерировал пароль для "приложения" mephi22.
- Обновил пароль и аккаунт в `.env`.