### PR TITLE
Fix retest module

### DIFF
--- a/public/js/retest.js
+++ b/public/js/retest.js
@@ -2,10 +2,24 @@
  * Created by Станислав on 15.03.16.
  */
 
+function sendForm() {
+  $('#send_button').trigger('click');
+}
+
+$('#set_button').on('click', function(){
+    console.log('GO');
+    $('input[name ^= fns]').each(function(){
+        $(this).closest(".fine-row").prev().remove();
+        $(this).closest(".fine-row").remove();
+    });
+    setTimeout(sendForm, 500);
+});
+
 var retestForm = $('#retest-form');
 
 /** функция-хелпер для переноса значения из checkbox в hidden */
 $('#retest-table').on('change', '.flag', function(){
+    $(this).next().attr('name', "fines[]");
     if ($(this).prop("checked"))                                                                                        //если галка стоит, то ставим в скрытое поле 1
         $(this).next().val(1);
     else $(this).next().val(0);                                                                                         //иначе 0

--- a/resources/views/personal_account/retest.blade.php
+++ b/resources/views/personal_account/retest.blade.php
@@ -90,7 +90,7 @@ full
                         <div class="checkbox checkbox-styled">
                             <label>
                                 <input type="checkbox" class="flag"  @if ($fine['access'] == 1) checked @endif>
-                                <input class="support-checkbox" name="fines[]" type="hidden" @if ($fine['access'] == 1) value="1"
+                                <input class="support-checkbox" name="fns[]" type="hidden" @if ($fine['access'] == 1) value="1"
                                 @else value="0"
                                 @endif
                                 >
@@ -107,8 +107,11 @@ full
                 @endforeach
                 </tbody>
             </table>
+            <div class="col-lg-offset-9"  id="change"  style="display: none">
+                <button id="send_button" class="btn btn-primary btn-raised submit-test" type="submit">Кнопка отправки формы</button>
+            </div>
             <div class="col-lg-offset-9"  id="change">
-                <button class="btn btn-primary btn-raised submit-test" type="submit">Применить изменения</button>
+                <button id="set_button" class="btn btn-primary btn-raised">Применить изменения</button>
             </div>
             </form>
         </div>


### PR DESCRIPTION
Таблица, которая отправлялась в форму, была слишком большая, учитывалось только 332 строк (input-ов) сверху таблицы.
Когда применялся фильтр, строки просто прятались, но в форме по-прежнему отправлялась вся таблица на сервер
Сделал так, чтобы отправлялись только те строки, которые были изменены